### PR TITLE
fix delete modal icon on mobile

### DIFF
--- a/src/components/ActionsTask/index.tsx
+++ b/src/components/ActionsTask/index.tsx
@@ -1,5 +1,7 @@
+import { AlertDialogTrigger } from '@radix-ui/react-alert-dialog';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { FiCheck, FiEdit, FiTrash, FiMoreVertical } from 'react-icons/fi';
+import { ModalDeleteTask } from '../ModalDeleteTask';
 import { DropdownContent, DropdownTrigger, Option } from './styles';
 
 interface ActionsTaskProps {
@@ -31,12 +33,14 @@ export function ActionsTask({ markAsFinished, handleDelete, handleEditTask }: Ac
             </Option>
           </DropdownMenu.Item>
 
-          <DropdownMenu.Item onSelect={handleDelete}>
-            <Option>
-              Excluir Tarefa
-              <FiTrash />
-            </Option>
-          </DropdownMenu.Item>
+          <ModalDeleteTask handleDeleteTask={handleDelete}>
+            <AlertDialogTrigger asChild>
+              <Option>
+                Excluir Tarefa
+                <FiTrash />
+              </Option>
+            </AlertDialogTrigger>
+          </ModalDeleteTask>
         </DropdownContent>
       </DropdownMenu.Portal>
 

--- a/src/components/ActionsTask/styles.ts
+++ b/src/components/ActionsTask/styles.ts
@@ -1,5 +1,4 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { darken } from "polished";
 import styled from "styled-components";
 
 export const Option = styled.div`
@@ -13,6 +12,10 @@ export const Option = styled.div`
   &:hover, &:focus, &:active {
     background-color: ${props => props.theme.colors.gray[300]};
     color: ${props => props.theme.colors.background}
+  }
+
+  button {
+    padding: 0;
   }
 `
 

--- a/src/components/ModalDeleteTask/index.tsx
+++ b/src/components/ModalDeleteTask/index.tsx
@@ -1,5 +1,5 @@
 import * as AlertDialog from '@radix-ui/react-alert-dialog'
-import { useState } from 'react'
+import { ReactNode } from 'react'
 import { FiTrash } from 'react-icons/fi';
 import { Button } from '../Button';
 import { IconButton } from '../IconButton';
@@ -7,24 +7,29 @@ import { AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDe
 
 interface ModalDeleteTaskProps {
   handleDeleteTask: () => void;
+  children?: ReactNode;
 }
 
-export function ModalDeleteTask({ handleDeleteTask }: ModalDeleteTaskProps) {
-  const [isModalDeleteOpen, setIsModalDeleteOpen] = useState(false);
-  
+export function ModalDeleteTask({ handleDeleteTask, children }: ModalDeleteTaskProps) {
   return (
-    <AlertDialog.Root open={isModalDeleteOpen} onOpenChange={() => setIsModalDeleteOpen(!isModalDeleteOpen)}>
-      <AlertDialog.Trigger asChild>
-        <IconButton icon={FiTrash} title="Excluir tarefa" />
-      </AlertDialog.Trigger>
+    <AlertDialog.Root>
+      {
+        children ? (
+          children
+        ) : (
+          <AlertDialog.Trigger asChild>
+            <IconButton icon={FiTrash} title="Excluir tarefa" />
+          </AlertDialog.Trigger>
+        )
+      }
       <AlertDialog.Portal>
         <AlertDialogOverlay />
         <AlertDialogContent>
           <AlertDialogTitle>
-            Teste
+            Excluir
           </AlertDialogTitle>
           <AlertDialogDescription>
-            Esta ação não pode ser desfeita. Isso irá deletar a tarefa permanentemente.
+            Esta ação não pode ser desfeita. Isso irá excluir a tarefa permanentemente.
           </AlertDialogDescription>
           <ButtonsContainer>
             <AlertDialogCancel asChild>
@@ -34,7 +39,7 @@ export function ModalDeleteTask({ handleDeleteTask }: ModalDeleteTaskProps) {
             </AlertDialogCancel>
             <AlertDialogAction asChild>
               <Button aria-label="Confirmar deleção da tarefa" type="button" onClick={handleDeleteTask}>
-                Sim, deletar
+                Sim, excluir
               </Button>
             </AlertDialogAction>
           </ButtonsContainer>


### PR DESCRIPTION
When the option "Excluir Tarefa" was clicked on mobile devices, there was no confirmation modal. So I fixed that issue.